### PR TITLE
Added get ensemble by id endpoint

### DIFF
--- a/src/ensembles/ensembles.controller.ts
+++ b/src/ensembles/ensembles.controller.ts
@@ -1,6 +1,13 @@
-import { Controller, Get, NotFoundException, Query } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+} from "@nestjs/common";
 
 import { EnsemblesService } from "./ensembles.service";
+import { getId } from "./lib/get-id";
 import { getLimit } from "./lib/get-limit";
 import { getPage } from "./lib/get-page";
 
@@ -26,5 +33,15 @@ export class EnsemblesController {
       data: ensembles,
       length: ensembles.length,
     };
+  }
+
+  @Get("/:id")
+  async getEnsemble(@Param("id") id: string) {
+    const idValue = getId(id);
+    const ensemble = await this.ensemblesService.findById(idValue);
+    if (!ensemble) {
+      throw new NotFoundException("Ensemble not found");
+    }
+    return ensemble;
   }
 }

--- a/src/ensembles/ensembles.service.ts
+++ b/src/ensembles/ensembles.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { Model } from "mongoose";
 
-import { Ensemble } from "./ensembles.schema";
+import { Ensemble, type EnsembleDocument } from "./ensembles.schema";
 
 @Injectable()
 export class EnsemblesService {
@@ -21,11 +21,19 @@ export class EnsemblesService {
     return this.ensembleModel.find().skip(skip).limit(limit).exec();
   }
 
-  async insertMany(ensembles: Ensemble[]): Promise<Ensemble[]> {
+  async insertMany(ensembles: Ensemble[]): Promise<EnsembleDocument[]> {
     return this.ensembleModel.insertMany(ensembles);
+  }
+
+  async insertOne(ensemble: Ensemble): Promise<EnsembleDocument> {
+    return await this.ensembleModel.create(ensemble);
   }
 
   async deleteAll(): Promise<void> {
     await this.ensembleModel.deleteMany();
+  }
+
+  async findById(id: string): Promise<Ensemble | null> {
+    return this.ensembleModel.findById(id).exec();
   }
 }

--- a/src/ensembles/lib/get-id.ts
+++ b/src/ensembles/lib/get-id.ts
@@ -1,0 +1,13 @@
+import { BadRequestException } from "@nestjs/common";
+import { z } from "zod";
+
+export function getId(id: unknown) {
+  const schema = z.coerce.string().min(24).max(24); // 24 characters long for id
+
+  try {
+    return schema.parse(id);
+  } catch (error) {
+    console.error(error);
+    throw new BadRequestException("Invalid parameter: id");
+  }
+}

--- a/test/ensembles.e2e-spec.ts
+++ b/test/ensembles.e2e-spec.ts
@@ -23,6 +23,66 @@ describe("EnsemblesController (e2e)", () => {
     await app.init();
   });
 
+  describe("GET /v1/ensembles/:id", () => {
+    it("should return the ensemble with the given id", async () => {
+      // Arrange
+      const ensemble = await ensemblesService.insertOne(mockEnsembles[0]);
+      const expected = mockEnsembles[0];
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/v1/ensembles/${String(ensemble._id)}`,
+      );
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject(expected);
+    });
+
+    it("should return 400 when an invalid id is provided", async () => {
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        "/v1/ensembles/invalid",
+      );
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        statusCode: 400,
+        message: "Invalid parameter: id",
+        error: "Bad Request",
+      });
+    });
+
+    it("should return 404 when no ensemble is found", async () => {
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        "/v1/ensembles/123456789012345678901234",
+      );
+
+      // Assert
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        statusCode: 404,
+        message: "Ensemble not found",
+      });
+    });
+
+    it("should return 400 when the id is too long", async () => {
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        "/v1/ensembles/1234567890123456789012345",
+      );
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        statusCode: 400,
+        message: "Invalid parameter: id",
+      });
+    });
+  });
+
   describe("GET /v1/ensembles", () => {
     it("should return 200 when no page or limit is provided", async () => {
       // Arrange

--- a/test/mocks/ensembles.mock.ts
+++ b/test/mocks/ensembles.mock.ts
@@ -182,4 +182,4 @@ export const mockEnsembles = [
     created_at: "2023-11-17T07:30:00Z",
     updated_at: "2024-12-05T13:00:00Z",
   },
-] satisfies Ensemble[];
+] satisfies Array<Ensemble & { _id?: string }>;


### PR DESCRIPTION
This pull request introduces several enhancements to the `ensembles` module, including a new endpoint for fetching an ensemble by its ID, validation for the ID parameter, and corresponding tests to ensure these functionalities work correctly.

### New endpoint and ID validation:

* [`src/ensembles/ensembles.controller.ts`](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5L1-R10): Added a new `GET /:id` endpoint to fetch an ensemble by its ID and imported the `getId` utility for ID validation. [[1]](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5L1-R10) [[2]](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5R37-R46)
* [`src/ensembles/lib/get-id.ts`](diffhunk://#diff-19283c2952db13868a06dc53631c7fe7ae4c3e3b45aae6661bada9ed40df08fbR1-R13): Created a new `getId` function to validate the ID parameter using the `zod` library and handle errors appropriately.

### Service enhancements:

* [`src/ensembles/ensembles.service.ts`](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L5-R5): Updated the `insertMany` method to return `EnsembleDocument[]` instead of `Ensemble[]`, added a new `insertOne` method, and implemented the `findById` method to fetch an ensemble by its ID. [[1]](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L5-R5) [[2]](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L24-R38)

### Testing:

* [`test/ensembles.e2e-spec.ts`](diffhunk://#diff-00ee548c2a02ab0ab1867c7254f322e2d098270308ad4be0b117e24d4ba7f995R26-R85): Added tests for the new `GET /v1/ensembles/:id` endpoint, including cases for valid IDs, invalid IDs, non-existent ensembles, and overly long IDs.
* [`test/mocks/ensembles.mock.ts`](diffhunk://#diff-5e10eb19b937b4c97ab3c46318cb50c55271df3405f870accb5959e295f9a13eL185-R185): Adjusted the mock ensembles to satisfy the new type requirements.