### PR TITLE
Feature/create delete ensemble

### DIFF
--- a/src/ensembles/ensembles.controller.ts
+++ b/src/ensembles/ensembles.controller.ts
@@ -8,8 +8,8 @@ import {
   Post,
   Query,
 } from "@nestjs/common";
-import { validate } from "src/util/validation";
 
+import { validate } from "../../src/util/validation";
 import { EnsemblesService } from "./ensembles.service";
 import { getId } from "./lib/get-id";
 import { getLimit } from "./lib/get-limit";
@@ -56,6 +56,8 @@ export class EnsemblesController {
       schema: createEnsembleBodySchema,
       value: createEnsembleBody,
     });
+
+    // TODO: Add validation whether the user already exists
 
     const timestamp = new Date().toISOString();
     return this.ensemblesService.insertOne({

--- a/src/ensembles/ensembles.controller.ts
+++ b/src/ensembles/ensembles.controller.ts
@@ -8,11 +8,13 @@ import {
   Post,
   Query,
 } from "@nestjs/common";
+import { validate } from "src/util/validation";
 
 import { EnsemblesService } from "./ensembles.service";
 import { getId } from "./lib/get-id";
 import { getLimit } from "./lib/get-limit";
 import { getPage } from "./lib/get-page";
+import { createEnsembleBodySchema } from "./lib/validation-schemas";
 
 @Controller("v1/ensembles")
 export class EnsemblesController {
@@ -48,14 +50,19 @@ export class EnsemblesController {
     return ensemble;
   }
 
-  @Post("/:id")
-  async createEnsemble(@Param("id") id: string, @Body() body: unknown) {
-    const idValue = getId(id);
-    const ensemble = await this.ensemblesService.findById(idValue);
-    if (ensemble) {
-      throw new NotFoundException("Ensemble already exists");
-    }
-    return this.ensemblesService.addEnsemble({ _id: idValue });
+  @Post("/")
+  async createEnsemble(@Body() createEnsembleBody: unknown) {
+    const body = validate({
+      schema: createEnsembleBodySchema,
+      value: createEnsembleBody,
+    });
+
+    const timestamp = new Date().toISOString();
+    return this.ensemblesService.insertOne({
+      ...body,
+      created_at: timestamp,
+      updated_at: timestamp,
+    });
   }
 
   @Delete("/:id")

--- a/src/ensembles/ensembles.controller.ts
+++ b/src/ensembles/ensembles.controller.ts
@@ -1,8 +1,11 @@
 import {
+  Body,
   Controller,
+  Delete,
   Get,
   NotFoundException,
   Param,
+  Post,
   Query,
 } from "@nestjs/common";
 
@@ -42,6 +45,27 @@ export class EnsemblesController {
     if (!ensemble) {
       throw new NotFoundException("Ensemble not found");
     }
+    return ensemble;
+  }
+
+  @Post("/:id")
+  async createEnsemble(@Param("id") id: string, @Body() body: unknown) {
+    const idValue = getId(id);
+    const ensemble = await this.ensemblesService.findById(idValue);
+    if (ensemble) {
+      throw new NotFoundException("Ensemble already exists");
+    }
+    return this.ensemblesService.addEnsemble({ _id: idValue });
+  }
+
+  @Delete("/:id")
+  async deleteEnsemble(@Param("id") id: string) {
+    const idValue = getId(id);
+    const ensemble = await this.ensemblesService.findById(idValue);
+    if (!ensemble) {
+      throw new NotFoundException("Ensemble not found");
+    }
+    await this.ensemblesService.softDeleteOne(idValue);
     return ensemble;
   }
 }

--- a/src/ensembles/ensembles.service.ts
+++ b/src/ensembles/ensembles.service.ts
@@ -16,9 +16,18 @@ export class EnsemblesService {
   }: {
     page?: number;
     limit?: number;
-  }): Promise<Ensemble[]> {
+  }): Promise<EnsembleDocument[]> {
     const skip = (page - 1) * limit; // Calculate the number of documents to skip
     return this.ensembleModel.find().skip(skip).limit(limit).exec();
+  }
+
+  async findById(id: string): Promise<EnsembleDocument | null> {
+    return this.ensembleModel
+      .findOne({
+        _id: id,
+        deactivated_at: { $exists: false },
+      })
+      .exec();
   }
 
   async insertMany(ensembles: Ensemble[]): Promise<EnsembleDocument[]> {
@@ -33,7 +42,13 @@ export class EnsemblesService {
     await this.ensembleModel.deleteMany();
   }
 
-  async findById(id: string): Promise<Ensemble | null> {
-    return this.ensembleModel.findById(id).exec();
+  async softDeleteOne(id: string): Promise<EnsembleDocument | null> {
+    return this.ensembleModel
+      .findByIdAndUpdate(
+        id,
+        { deactivated_at: new Date().toISOString() },
+        { new: true },
+      )
+      .exec();
   }
 }

--- a/src/ensembles/lib/delete-ensemble.ts
+++ b/src/ensembles/lib/delete-ensemble.ts
@@ -1,0 +1,13 @@
+import { BadRequestException } from "@nestjs/common";
+import { z } from "zod";
+
+export function deleteEnsemble(id: unknown) {
+  const schema = z.coerce.string().min(24).max(24); // 24 characters long for id
+
+  try {
+    return schema.parse(id);
+  } catch (error) {
+    console.error(error);
+    throw new BadRequestException("Invalid parameter: id");
+  }
+}

--- a/src/ensembles/lib/post-ensemble.ts
+++ b/src/ensembles/lib/post-ensemble.ts
@@ -1,0 +1,13 @@
+import { BadRequestException } from "@nestjs/common";
+import { z } from "zod";
+
+export function postEnsemble(id: unknown) {
+  const schema = z.coerce.string().min(24).max(24); // 24 characters long for id
+
+  try {
+    return schema.parse(id);
+  } catch (error) {
+    console.error(error);
+    throw new BadRequestException("Invalid parameter: id");
+  }
+}

--- a/src/ensembles/lib/validation-schemas.ts
+++ b/src/ensembles/lib/validation-schemas.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const createEnsembleBodySchema = z.object({
+  name: z.string(),
+  imageUrl: z.string().url(),
+  description: z.string(),
+  website: z.string().url(),
+  zip_code: z.string(),
+  city: z.string(),
+  active_musicians: z.enum(["1-4", "5-9", "10-24", "25-49", "50+"]),
+  practice_frequency: z.enum([
+    "daily",
+    "weekly",
+    "bi-weekly",
+    "monthly",
+    "bi-monthly",
+  ]),
+  ensemble_type: z.array(z.enum(["continuous", "project_based"])),
+  genre: z.array(
+    z.enum([
+      "baroque",
+      "folk",
+      "chamber",
+      "romantic",
+      "late-modern",
+      "late-romantic",
+      "symphonic",
+    ]),
+  ),
+  admin_user_id: z.string(),
+});
+
+export type CreateEnsembleBody = z.infer<typeof createEnsembleBodySchema>;

--- a/test/ensembles.e2e-spec.ts
+++ b/test/ensembles.e2e-spec.ts
@@ -68,6 +68,26 @@ describe("EnsemblesController (e2e)", () => {
       });
     });
 
+    it("should return 404 when no ensemble is found but is deactivated", async () => {
+      // Arrange
+      const ensemble = await ensemblesService.insertOne({
+        ...mockEnsembles[0],
+        deactivated_at: new Date().toISOString(),
+      });
+
+      // Act
+      const response = await request(app.getHttpServer()).get(
+        `/v1/ensembles/${String(ensemble._id)}`,
+      );
+
+      // Assert
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        statusCode: 404,
+        message: "Ensemble not found",
+      });
+    });
+
     it("should return 400 when the id is too long", async () => {
       // Act
       const response = await request(app.getHttpServer()).get(

--- a/test/ensembles.e2e-spec.ts
+++ b/test/ensembles.e2e-spec.ts
@@ -4,6 +4,7 @@ import { type Server } from "http";
 import * as request from "supertest";
 
 import { EnsemblesService } from "../src/ensembles/ensembles.service";
+import type { CreateEnsembleBody } from "../src/ensembles/lib/validation-schemas";
 import { TestModule } from "../src/test.module";
 import { mockEnsembles } from "./mocks/ensembles.mock";
 
@@ -213,6 +214,57 @@ describe("EnsemblesController (e2e)", () => {
       expect(response.body).toMatchObject({
         statusCode: 404,
         message: "No ensembles found",
+      });
+    });
+  });
+
+  describe("DELETE /v1/ensembles/:id", () => {
+    it("should return 200 when the ensemble is successfully deactivated", async () => {
+      // Arrange
+      const ensemble = await ensemblesService.insertOne(mockEnsembles[0]);
+      const response = await request(app.getHttpServer()).delete(
+        `/v1/ensembles/${String(ensemble._id)}`,
+      );
+      // Assert
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject(mockEnsembles[0]);
+    });
+  });
+
+  describe("POST /v1/ensembles", () => {
+    it("should return 201 when the ensemble is successfully created", async () => {
+      // Arrange
+      const ensemble = {
+        ...mockEnsembles[0],
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        created_at: expect.any(String),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        updated_at: expect.any(String),
+      };
+      const response = await request(app.getHttpServer())
+        .post("/v1/ensembles")
+        .send(ensemble);
+      // Assert
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject(
+        ensemble satisfies CreateEnsembleBody,
+      );
+    });
+
+    it("should return 400 when the ensemble is invalid", async () => {
+      // Arrange
+      const ensemble = {
+        ...mockEnsembles[0],
+        // @ts-expect-error - intentionally invalid
+        name: undefined,
+      } satisfies CreateEnsembleBody;
+      const response = await request(app.getHttpServer())
+        .post("/v1/ensembles")
+        .send(ensemble);
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        message: "Validation failed",
       });
     });
   });


### PR DESCRIPTION
This pull request introduces new endpoints for creating and deleting ensembles, along with associated validation and error handling. It also includes updates to the service layer and end-to-end tests to support these new functionalities.

### New Endpoints and Validation:

* [`src/ensembles/ensembles.controller.ts`](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5R2-R17): Added `POST` and `DELETE` endpoints for creating and deleting ensembles. Added validation using `createEnsembleBodySchema` and `validate` function. [[1]](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5R2-R17) [[2]](diffhunk://#diff-edecd290872ff791a7a035cce4eb3af20f6913ad7bb5ce11269ba444edb39db5R52-R79)
* [`src/ensembles/lib/validation-schemas.ts`](diffhunk://#diff-8c78f13109fd10ea08bd83a9ed4cf48a302bf2570ad1f702ad8592a9f6c99035R1-R33): Defined `createEnsembleBodySchema` for validating the request body of the `POST` endpoint.
* [`src/ensembles/lib/delete-ensemble.ts`](diffhunk://#diff-56cbab37fbf1b6befe9188d8b34f9b33bc0a11b6e18298bfbb3e983705a9d421R1-R13): Added validation for the `DELETE` endpoint to ensure the provided ID is valid.
* [`src/ensembles/lib/post-ensemble.ts`](diffhunk://#diff-d9a53826c1535f25bcbec4db4ffd9fe263ec4957f58828f9d76f047913839a78R1-R13): Added validation for the `POST` endpoint to ensure the provided ID is valid.

### Service Layer Updates:

* [`src/ensembles/ensembles.service.ts`](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L19-R32): Updated the `findById` method to exclude deactivated ensembles. Added `softDeleteOne` method to mark ensembles as deactivated instead of permanently deleting them. [[1]](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L19-R32) [[2]](diffhunk://#diff-a1e666b874b8c496ec98aff81f2981b26f8c2b69456769819e696c592d9966e7L36-R52)

### End-to-End Tests:

* [`test/ensembles.e2e-spec.ts`](diffhunk://#diff-00ee548c2a02ab0ab1867c7254f322e2d098270308ad4be0b117e24d4ba7f995R7): Added tests for the new `POST` and `DELETE` endpoints, including scenarios for successful creation/deletion and validation errors. [[1]](diffhunk://#diff-00ee548c2a02ab0ab1867c7254f322e2d098270308ad4be0b117e24d4ba7f995R7) [[2]](diffhunk://#diff-00ee548c2a02ab0ab1867c7254f322e2d098270308ad4be0b117e24d4ba7f995R72-R91) [[3]](diffhunk://#diff-00ee548c2a02ab0ab1867c7254f322e2d098270308ad4be0b117e24d4ba7f995R220-R270)